### PR TITLE
make thumbnail example compilable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ To add this package to your project, use this:
 
 ```typ
 #import "@preview/cetz:0.3.4"
-#import "@preview/pull-eh:0.1.0": *
-
-...
+#import "@preview/pull-eh:0.1.0"
 
 #cetz.canvas(length: 2cm, {
   import cetz.draw: *


### PR DESCRIPTION
Not sure how it got overlooked, but the example is not compilable, and there is `...` added, for some reason.

Not ideal (without scripts), but I add the examples to Tytanic and then copy them verbatim to `README.md`, so they are 100% correct.

https://codeberg.org/Andrew15-5/text-dirr

https://codeberg.org/Andrew15-5/magnifying-glass

Also looks like `manual.pdf` is not updated.